### PR TITLE
Cleanup JS code

### DIFF
--- a/htpc/root.py
+++ b/htpc/root.py
@@ -30,7 +30,7 @@ class Root:
         """ Shutdown CherryPy and exit script """
         self.logger.info("Shutting down htpc-manager.")
         cherrypy.engine.exit()
-        sys.exit(0)
+        return "HTPC Manager has shut down"
 
     @cherrypy.expose()
     def restart(self):

--- a/interfaces/default/html/base.html
+++ b/interfaces/default/html/base.html
@@ -54,8 +54,8 @@ webdir = htpc.WEBDIR
                             <li><a href="http://github.com/styxit/HTPC-Manager"><i class="icon-github"></i> Github project</a></li>
                             <li><a href="#" id="btn-check-update"><i class="icon-eye-open"></i> Check for updates</a></li>
                             <li><a href="${htpc.WEBDIR}settings/" id="btn-settings"><i class="icon-cog"></i> Settings</a></li>
-                            <li><a href="#" id="btn-restart"><i class="icon-refresh"></i> Restart</a></li>
-                            <li><a href="#" id="btn-shutdown"><i class="icon-off"></i> Shutdown</a></li>
+                            <li><a href="${htpc.WEBDIR}restart" class="ajax-confirm" title="Restart HTPC-Manager"><i class="icon-refresh"></i> Restart</a></li>
+                            <li><a href="${htpc.WEBDIR}shutdown" class="confirm" title="Shutdown HTPC-Manager"><i class="icon-off"></i> Shutdown</a></li>
                           </ul>
                         </div>
                     </form>

--- a/interfaces/default/js/default.js
+++ b/interfaces/default/js/default.js
@@ -21,7 +21,6 @@ $(document).ready(function () {
             notify(link.text(), data, 'success');
         }, 'json');
     });
-
     $('a.ajax-confirm').click(function (e) {
         e.preventDefault();
         var link = $(this);
@@ -30,6 +29,9 @@ $(document).ready(function () {
             notify(link.attr('title'), data, 'warning');
           }, 'json');
         }
+    });
+    $('a.confirm').click(function (e) {
+        return(confirm($(this).attr('title') + '?'));
     });
 
     $('#btn-check-update').click(function (e) {
@@ -56,24 +58,6 @@ $(document).ready(function () {
                 }
             }
         }, 'json');
-    });
-    $('#btn-restart').click(function (e) {
-        e.preventDefault();
-        if (confirm('Restart?')) {
-            notify('Restart','Restart command sent...','success')
-            $.get(WEBDIR + 'restart', function() {
-                // On restart
-            }, 'json');
-        }
-    });
-    $('#btn-shutdown').click(function (e) {
-        e.preventDefault();
-        if (confirm('Shutdown?')) {
-            notify('Shutdown','Shutdown command sent.','success')
-            $.get(WEBDIR + 'shutdown', function() {
-                // On shutdown confirmed
-            }, 'json');
-        }
     });
 
     $('#modal_dialog').on('hidden', function () {


### PR DESCRIPTION
Instead of using ajax for shutdown point to a shutdown page (staying on the page seems illogical when the server is shutdown)
Have reboot use the new general ajax-confirm class.
