### PR TITLE
Deluge: ssl and base url options

### DIFF
--- a/modules/deluge.py
+++ b/modules/deluge.py
@@ -29,7 +29,7 @@ class Deluge:
                 {'type': 'text', 'label': 'IP / Host *', 'name': 'deluge_host'},
                 {'type': 'text', 'label': 'Port *', 'name': 'deluge_port'},
                 {'type': 'bool', 'label': 'Use SSL', 'name': 'deluge_ssl'},
-                {'type': 'text', 'label': 'Base path', 'name': 'deluge_basepath'},
+                {'type': 'text', 'label': 'Basepath', 'name': 'deluge_basepath'},
                 {'type': 'password', 'label': 'Password', 'name': 'deluge_password'}
         ]})
 


### PR DESCRIPTION
I have nginx as SSL proxy for deluge web-ui. There is also an option for deluge to change default url. My current deluge url is https://x.x.x.x:8081/tor
Check this thread if you have any questions: http://forum.deluge-torrent.org/viewtopic.php?f=7&t=10165&start=20
