### PR TITLE
Deluge: remove button removes selected torrent not the last one

### DIFF
--- a/interfaces/default/js/deluge.js
+++ b/interfaces/default/js/deluge.js
@@ -110,8 +110,9 @@ function getTorrents(){
             addClass('btn btn-mini').
             html('<i class="icon-remove"></i>').
             attr('title', 'Remove torrent').
+            attr('data-torrent-id', torrent.hash).
             click(function(){
-                setRemoveTorrentModal(torrent.hash);
+                setRemoveTorrentModal($(this).attr('data-torrent-id'));
             });
           buttons.append(removeButton);
 


### PR DESCRIPTION
Just removed some of my necessary torrents.((((((((((((((
You are always removing the last torrent of the page not the selected one.
