### PR TITLE
Dynamically import all modules.

### DIFF
--- a/Htpc.py
+++ b/Htpc.py
@@ -45,30 +45,15 @@ def load_modules():
     htpc.ROOT.log = Log()
     from htpc.updater import Updater
     htpc.ROOT.update = Updater()
-    from modules.xbmc import Xbmc
-    htpc.ROOT.xbmc = Xbmc()
-    from modules.sabnzbd import Sabnzbd
-    htpc.ROOT.sabnzbd = Sabnzbd()
-    from modules.couchpotato import Couchpotato
-    htpc.ROOT.couchpotato = Couchpotato()
-    from modules.sickbeard import Sickbeard
-    htpc.ROOT.sickbeard = Sickbeard()
-    from modules.transmission import Transmission
-    htpc.ROOT.transmission = Transmission()
-    from modules.deluge import Deluge
-    htpc.ROOT.deluge = Deluge()
-    from modules.squeezebox import Squeezebox
-    htpc.ROOT.squeezebox = Squeezebox()
-    from modules.search import Search
-    htpc.ROOT.search = Search()
-    from modules.utorrent import UTorrent
-    htpc.ROOT.utorrent = UTorrent()
-    from modules.nzbget import NZBGet
-    htpc.ROOT.nzbget = NZBGet()
-    from modules.qbittorrent import qbittorrent
-    htpc.ROOT.qbittorrent = qbittorrent()
-    from modules.stats import Stats
-    htpc.ROOT.stats = Stats()
+
+    # Dynamically import all modules.
+    import inspect
+    for module in os.listdir('modules'):
+        if module.endswith('.py') and not module.startswith('_'):
+            __import__('modules.' + module[0:-3])
+            for name, obj in inspect.getmembers(sys.modules['modules.' + module[0:-3]]):
+                if inspect.isclass(obj) and name.lower() == module[0:-3]:
+                    setattr(htpc.ROOT, module[0:-3], obj())
 
 
 def main():


### PR DESCRIPTION
I was poking around in the source code as I'm trying to skill up on Python, and I decided the the module import code could probably be optimised a bit so that any modules in the modules folder will be imported and have there main class attached automatically.
