### PR TITLE
Add web-app support for iOS and ...

### DIFF
--- a/interfaces/default/html/base.html
+++ b/interfaces/default/html/base.html
@@ -9,6 +9,8 @@ webdir = htpc.WEBDIR
     <title>HTPC Manager</title>
     <link href="${htpc.WEBDIR}favicon.ico" type="image/x-icon" rel="icon">
     <link rel="apple-touch-icon" href="${htpc.WEBDIR}img/ios/homescreen.png">
+    <meta name="mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-capable" content="yes">
 
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.0, user-scalable=no">
     <link href="${htpc.WEBDIR}css/themes/${s.get('app_theme','default')}/bootstrap.min.css" rel="stylesheet" />


### PR DESCRIPTION
... Android with Chrome.  

Using the added meta tags, HTPC-Manager can be added to the home screen of any iOS device or Android device with Chrome intalled and will run like a native app. This includes caching web pages for offline viewing as well as running fullscreen and having it's own entry in the native task manager. This makes it much cleaner to run on phones without changing anything major.  

For Android:  
1. Install Chrome
2. Open HTPC-Manager web page in Chrome.
   ![screenshot_2014-08-05-10-27-57](https://cloud.githubusercontent.com/assets/1206702/3814952/ea5e829a-1cbf-11e4-8128-ae70d7738c38.png)
3. Tap the menu Icon in the top right and select "Add to Homescreen".
   ![screenshot_2014-08-05-10-28-06](https://cloud.githubusercontent.com/assets/1206702/3814957/fdc0d748-1cbf-11e4-9717-2a6ad0de9559.png)
4. Choose a name and tap "Add".
   ![screenshot_2014-08-05-10-28-12](https://cloud.githubusercontent.com/assets/1206702/3814961/02f763e4-1cc0-11e4-9768-fdc0af8679e8.png)
5. Open HTPC-Manager as a new Webapp.
   ![screenshot_2014-08-05-10-28-57](https://cloud.githubusercontent.com/assets/1206702/3814965/0ac5f64e-1cc0-11e4-8ee1-b97f41955adb.png)
   ![screenshot_2014-08-05-10-29-36](https://cloud.githubusercontent.com/assets/1206702/3814966/0cb2c6da-1cc0-11e4-94c5-42e77e896f11.png)
6. Shows up in task switcher as "Web App" with a screenshot.
   ![screenshot_2014-08-05-10-30-01](https://cloud.githubusercontent.com/assets/1206702/3814967/10251a3e-1cc0-11e4-94ff-71472937b1d3.png)
