### PR TITLE
Fixed Play / Pause bug for xbmc

### DIFF
--- a/interfaces/default/html/xbmc.html
+++ b/interfaces/default/html/xbmc.html
@@ -75,7 +75,7 @@
                             <button class="btn btn-small" data-player-control="skipprevious"><i class="icon-fast-backward"></i></button>
                             <button class="btn btn-small" data-player-control="stepback"><i class="icon-backward"></i></button>
                             <button class="btn btn-small" data-player-control="stop"><i class="icon-stop"></i></button>
-                            <button class="btn btn-small" data-player-control="play"><i class="icon-pause"></i></button>
+                            <button class="btn btn-small" data-player-control="playpause"><i class="icon-pause"></i></button>
                             <button class="btn btn-small" data-player-control="stepforward"><i class="icon-forward"></i></button>
                             <button class="btn btn-small" data-player-control="skipnext"><i class="icon-fast-forward"></i></button>
                             <button class="btn btn-small" data-player-control="getsub"><i class="icon-text-width"></i></button>


### PR DESCRIPTION
When controlling xbmc video playback from the
 currently playing applet the pause button did not work.
Replacing the RPC play call with playpause fixed the problem.
Tested on kodi 13.2 Git:20140901-867305b