### PR TITLE
Fix #387: fix deluge JSON queries

### DIFF
--- a/modules/deluge.py
+++ b/modules/deluge.py
@@ -132,7 +132,8 @@ class Deluge:
             url = 'http' + ssl + '://' +  host + ':' + str(port) + deluge_basepath + '/json'
             
             post_data = dumps(data)
-            buf = StringIO( self.opener.open(url, post_data,1).read())
+            req = urllib2.Request(url, data=post_data, headers={'Content-Type': 'application/json'})
+            buf = StringIO(self.opener.open(req, timeout=1).read())
             f = gzip.GzipFile(fileobj=buf)
             response = loads(f.read())
             self.logger.debug ("response for %s is %s" %(data,response))


### PR DESCRIPTION
Deluge now require the Content-Type header for JSON queries. Without the header deluge returns "500 Internal Server Error".
See #387